### PR TITLE
Добавлены тесты и реализация IoC-контейнера

### DIFF
--- a/OtusSpaceBattle.Tests/IoCTests.cs
+++ b/OtusSpaceBattle.Tests/IoCTests.cs
@@ -1,0 +1,157 @@
+using OtusSpaceBattle.Infrastructure;
+using OtusSpaceBattle.Adapters;
+using OtusSpaceBattle.Commands;
+using OtusSpaceBattle.Interfaces;
+using OtusSpaceBattle.Models;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OtusSpaceBattle.Tests
+{
+    public class IoCTests
+    {
+        [Fact]
+        public void CanRegisterAndResolveInRootScope()
+        {
+            IoC.Resolve("IoC.Register", "test.key", new Func<object[], object>(args => 42));
+            var result = IoC.Resolve("test.key");
+            Assert.Equal(42, result);
+        }
+
+        [Fact]
+        public void CanRegisterAndResolveWithArgs()
+        {
+            IoC.Resolve("IoC.Register", "sum", new Func<object[], object>(args => (int)args[0] + (int)args[1]));
+            var result = IoC.Resolve("sum", 2, 3);
+            Assert.Equal(5, result);
+        }
+
+        [Fact]
+        public void CanCreateAndSwitchScopes()
+        {
+            IoC.Resolve("Scopes.New", "scope1");
+            IoC.Resolve("Scopes.Current", "scope1");
+            IoC.Resolve("IoC.Register", "scoped.key", new Func<object[], object>(args => "scoped"));
+            var result = IoC.Resolve("scoped.key");
+            Assert.Equal("scoped", result);
+            IoC.Resolve("Scopes.Current", "root");
+            Assert.Throws<InvalidOperationException>(() => IoC.Resolve("scoped.key"));
+        }
+
+        [Fact]
+        public void ScopesAreThreadLocal()
+        {
+            IoC.Resolve("Scopes.New", "threadScope");
+            var t = new Thread(() =>
+            {
+                IoC.Resolve("Scopes.Current", "threadScope");
+                IoC.Resolve("IoC.Register", "thread.key", new Func<object[], object>(args => "threaded"));
+                var result = IoC.Resolve("thread.key");
+                Assert.Equal("threaded", result);
+            });
+            t.Start();
+            t.Join();
+            Assert.Throws<InvalidOperationException>(() => IoC.Resolve("thread.key"));
+        }
+
+        [Fact]
+        public void MultiThreadedScopesWorkIndependently()
+        {
+            IoC.Resolve("Scopes.New", "scopeA");
+            IoC.Resolve("Scopes.New", "scopeB");
+            string resultA = null, resultB = null;
+            var t1 = new Thread(() =>
+            {
+                IoC.Resolve("Scopes.Current", "scopeA");
+                IoC.Resolve("IoC.Register", "key", new Func<object[], object>(args => "A"));
+                resultA = (string)IoC.Resolve("key");
+            });
+            var t2 = new Thread(() =>
+            {
+                IoC.Resolve("Scopes.Current", "scopeB");
+                IoC.Resolve("IoC.Register", "key", new Func<object[], object>(args => "B"));
+                resultB = (string)IoC.Resolve("key");
+            });
+            t1.Start(); t2.Start();
+            t1.Join(); t2.Join();
+            Assert.Equal("A", resultA);
+            Assert.Equal("B", resultB);
+        }
+
+        [Fact]
+        public void CanRegisterAndResolveMoveCommand()
+        {
+            var mockUObject = new Moq.Mock<IUObject>();
+            mockUObject.Setup(x => x.GetProperty(nameof(IMovableObject.Position))).Returns((12, 5));
+            mockUObject.Setup(x => x.GetProperty(Constants.Velocity)).Returns(10);
+            mockUObject.Setup(x => x.GetProperty(nameof(IRotatableObject.DirectionsCount))).Returns(8);
+            mockUObject.Setup(x => x.GetProperty(nameof(IRotatableObject.Direction))).Returns(3);
+            (int, int) actualSetPosition = default;
+            mockUObject.Setup(x => x.SetProperty(nameof(IMovableObject.Position), Moq.It.IsAny<object>()))
+                .Callback<string, object>((name, value) => actualSetPosition = ((int, int))value);
+
+            IoC.Resolve("IoC.Register", "move", new Func<object[], object>(args =>
+                new MoveCommand(new MovingObjectAdapter((IUObject)args[0]), (IUObject)args[0])
+            ));
+            var moveCommand = (ICommand)IoC.Resolve("move", mockUObject.Object);
+            moveCommand.Execute();
+            Assert.Equal((5, 12), actualSetPosition);
+        }
+
+        [Fact]
+        public void CanRegisterAndResolveRotateCommand()
+        {
+            var mockUObject = new Moq.Mock<IUObject>();
+            mockUObject.Setup(x => x.GetProperty(nameof(IRotatableObject.Direction))).Returns(3);
+            mockUObject.Setup(x => x.GetProperty(nameof(IRotatableObject.DirectionsCountPerStep))).Returns(2);
+            mockUObject.Setup(x => x.GetProperty(nameof(IRotatableObject.DirectionsCount))).Returns(8);
+            int actualDirection = 0;
+            mockUObject.Setup(x => x.SetProperty(nameof(IRotatableObject.Direction), Moq.It.IsAny<object>()))
+                .Callback<string, object>((name, value) => actualDirection = (int)value);
+
+            IoC.Resolve("IoC.Register", "rotate", new Func<object[], object>(args =>
+                new RotateCommand(new RotatingObjectAdapter((IUObject)args[0]), (IUObject)args[0])
+            ));
+            var rotateCommand = (ICommand)IoC.Resolve("rotate", mockUObject.Object);
+            rotateCommand.Execute();
+            Assert.Equal(5, actualDirection);
+        }
+
+        [Fact]
+        public void CanRegisterAndResolveMacroCommand()
+        {
+            var mockUObject = new Moq.Mock<IUObject>();
+            mockUObject.Setup(x => x.GetProperty(nameof(IMovableObject.Position))).Returns((12, 5));
+            mockUObject.Setup(x => x.GetProperty(Constants.Velocity)).Returns(10);
+            mockUObject.Setup(x => x.GetProperty(nameof(IRotatableObject.DirectionsCountPerStep))).Returns(2);
+            mockUObject.Setup(x => x.GetProperty(nameof(IRotatableObject.DirectionsCount))).Returns(8);
+            mockUObject.Setup(x => x.GetProperty(nameof(IRotatableObject.Direction))).Returns(3);
+            (int, int) actualSetPosition = default;
+            mockUObject.Setup(x => x.SetProperty(nameof(IMovableObject.Position), Moq.It.IsAny<object>()))
+                .Callback<string, object>((name, value) => actualSetPosition = ((int, int))value);
+            int actualDirection = 0;
+            mockUObject.Setup(x => x.SetProperty(nameof(IRotatableObject.Direction), Moq.It.IsAny<object>()))
+                .Callback<string, object>((name, value) => actualDirection = (int)value);
+
+            IoC.Resolve("IoC.Register", "move", new Func<object[], object>(args =>
+                new MoveCommand(new MovingObjectAdapter((IUObject)args[0]), (IUObject)args[0])
+            ));
+            IoC.Resolve("IoC.Register", "rotate", new Func<object[], object>(args =>
+                new RotateCommand(new RotatingObjectAdapter((IUObject)args[0]), (IUObject)args[0])
+            ));
+            IoC.Resolve("IoC.Register", "macro", new Func<object[], object>(args =>
+                new MacroCommand(new List<ICommand> {
+                    (ICommand)IoC.Resolve("move", args[0]),
+                    (ICommand)IoC.Resolve("rotate", args[0])
+                })
+            ));
+            var macroCommand = (ICommand)IoC.Resolve("macro", mockUObject.Object);
+            macroCommand.Execute();
+            Assert.Equal((5, 12), actualSetPosition);
+            Assert.Equal(5, actualDirection);
+        }
+    }
+}

--- a/OtusSpaceBattle/Infrastructure/IoC.cs
+++ b/OtusSpaceBattle/Infrastructure/IoC.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace OtusSpaceBattle.Infrastructure
+{
+    public static class IoC
+    {
+        private class Scope
+        {
+            public readonly ConcurrentDictionary<string, Func<object[], object>> Registrations = new();
+        }
+
+        private static readonly ConcurrentDictionary<string, Scope> _scopes = new();
+        private static readonly ThreadLocal<string> _currentScope = new(() => "root");
+        static IoC()
+        {
+            _scopes.TryAdd("root", new Scope());
+        }
+
+        public static T Resolve<T>(string key, params object[] args)
+        {
+            return (T)Resolve(key, args);
+        }
+
+        public static object Resolve(string key, params object[] args)
+        {
+            var scope = _scopes[_currentScope.Value];
+            switch (key)
+            {
+                case "IoC.Register":
+                    // args: [string regKey, Func<object[], object> factory]
+                    var regKey = (string)args[0];
+                    var factory = (Func<object[], object>)args[1];
+                    scope.Registrations[regKey] = factory;
+                    return new Action(() => { });
+                case "Scopes.New":
+                    // args: [string scopeId]
+                    var newScopeId = (string)args[0];
+                    _scopes.TryAdd(newScopeId, new Scope());
+                    return new Action(() => { });
+                case "Scopes.Current":
+                    // args: [string scopeId]
+                    var curScopeId = (string)args[0];
+                    if (!_scopes.ContainsKey(curScopeId))
+                        throw new InvalidOperationException($"Scope '{curScopeId}' does not exist.");
+                    _currentScope.Value = curScopeId;
+                    return new Action(() => { });
+                default:
+                    if (scope.Registrations.TryGetValue(key, out var creator))
+                        return creator(args);
+                    throw new InvalidOperationException($"No registration for key '{key}' in scope '{_currentScope.Value}'.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Описание/Пошаговая инструкция выполнения домашнего задания: В игре Космичекий бой есть набор операций над игровыми объектами: движение по прямой, поворот, выстрел. При этом содержание этих команд может отличаться для разных игр, в зависимости от того, какие правила игры были выбраны пользователями. Например, пользователи могут ограничить запас ход каждого корабля некоторым количеством топлива, а другой игре запретить поворачиваться кораблям по часовой стрелке и т.д.

IoC может помочь в этом случае, скрыв детали в стратегии разрешения зависимости.

Например,

IoC.Resolve("двигаться прямо", obj);

Возвращает команду, которая чаще всего является макрокомандой и осуществляет один шаг движения по прямой.

Реализовать IoC контейнер, который:

Разрешает зависимости с помощью метода, со следующей сигнатурой: T IoC.Resolve(string key, params object[] args);

Указание: Если язык программирования не поддерживает Generics, как, например, PHP, то

Запись Вам может быть незнакома. Так оеализуется параметрический полиморфизм в таких языках, как C++, C#, Java, Kotlin и др.

Тогда просто возвращайте просто ссылку на базовый класс.

Регистрация зависимостей также происходит с помощью метода Resolve

IoC.Resolve("IoC.Register", "aaa", (args) => new A()).Execute();

Зависимости можно регистрировать в разных "скоупах" IoC.Resolve("Scopes.New", "scopeId").Execute();
IoC.Resolve("Scopes.Current", "scopeId").Exceute();

Указание: Если Ваш фреймворк допускает работу с многопоточным кодом, то для работы со скоупами используйте ThreadLocal контейнер.

Критерии оценки:
Интерфейс IoC устойчив к изменению требований. Оценка: 0 - 3 балла (0 - совсем не устойчив, 3 - преподаватель не смог построить ни одного контрпримера) IoC предоставляет ровно один метод для всех операций. 1 балл IoC предоставляет работу со скоупами для предотвращения сильной связности. 2 балла. Реализованы модульные тесты. 2 балла
Реализованы многопоточные тесты. 2 балла